### PR TITLE
fix: remove answers from modules exercise

### DIFF
--- a/topics/modules/exercises/src/lib.rs
+++ b/topics/modules/exercises/src/lib.rs
@@ -1,2 +1,0 @@
-pub mod math;
-pub mod util;

--- a/topics/modules/exercises/src/math.rs
+++ b/topics/modules/exercises/src/math.rs
@@ -1,7 +1,0 @@
-pub fn min(x: u32, y: u32) -> u32 {
-    if x <= y { x } else { y }
-}
-
-pub fn max(x: u32, y: u32) -> u32 {
-    if x >= y { x } else { y }
-}

--- a/topics/modules/exercises/src/util/log.rs
+++ b/topics/modules/exercises/src/util/log.rs
@@ -1,3 +1,0 @@
-pub fn debug(s: &str) {
-    println!("DEBUG: {s}");
-}

--- a/topics/modules/exercises/src/util/mod.rs
+++ b/topics/modules/exercises/src/util/mod.rs
@@ -1,2 +1,0 @@
-pub mod log;
-pub mod vec;

--- a/topics/modules/exercises/src/util/vec.rs
+++ b/topics/modules/exercises/src/util/vec.rs
@@ -1,9 +1,0 @@
-pub fn first(v: &[u32]) -> Option<u32> {
-    let n = v.len();
-    if n > 0 { Some(v[0]) } else { None }
-}
-
-pub fn last(v: &[u32]) -> Option<u32> {
-    let n = v.len();
-    if n > 0 { Some(v[n - 1]) } else { None }
-}


### PR DESCRIPTION
## Description
This PR removes solution files from the topics/modules/exercises/src directory. The deleted files included implementations for util / math functions and module structure that were part of the answer to the Rust modules exercise.

## Changes Made
	•	Deleted lib.rs, math.rs, and the entire util module (log.rs, vec.rs, mod.rs) under topics/modules/exercises/src.

## Reason for Change
These files contained complete solutions to the module exercises and should not be present in the exercise scaffolding. Removing them ensures that learners can attempt the exercises from scratch without access to the answers.

As the current exercise is just about adding a `use my_modules::{math, util};` statement and deleting the functions from the main file, leaving these implementation files in place undermines the exercise’s purpose.