### PR TITLE
feat: add examples for hello

### DIFF
--- a/topics/hello/README.md
+++ b/topics/hello/README.md
@@ -1,5 +1,13 @@
 # Hello
 
+## Example
+
+Execute the following command to run [`./solutions/examples/hello.rs`](./solutions/examples/hello.rs)
+
+```shell
+cargo run --example hello
+```
+
 ## Exercises
 
 Exercises are in [`./exercises/src/main.rs`](./exercises/src/main.rs)

--- a/topics/hello/solutions/examples/hello.rs
+++ b/topics/hello/solutions/examples/hello.rs
@@ -1,0 +1,5 @@
+#![allow(unused)]
+
+fn main() {
+    println!("Hello, World!");
+}


### PR DESCRIPTION
### Summary
This is a user experience improvement for the `hello` example.

### Why
While following the "[hello](https://updraft.cyfrin.io/courses/rust-programming-basics/rust-intro/hello)" section of the Updraft Cyfrin course, I noticed that the video runs `cargo run --example hello`, but the actual project does not contain an `examples/hello.rs` file. As a result, trying to run the same command locally causes an error. This discrepancy between the video and the codebase can be confusing for novice learners. This PR adds the missing example and update the README.md to align with the course content and improve the learning experience.

<img width="1452" height="815" alt="locate_in_video" src="https://github.com/user-attachments/assets/4e3c494e-4da6-4a4c-8662-ec5e734afc5f" />

