### PR TITLE
Add missing test for Rectangle struct in the Generic Types section.

### DIFF
--- a/topics/generic_type/exercises/tests/test.rs
+++ b/topics/generic_type/exercises/tests/test.rs
@@ -11,3 +11,23 @@ fn test_last() {
     assert_eq!(last(('a', "hello")), "hello");
     assert_eq!(last((1u32, 0i32)), 0i32);
 }
+
+#[test]
+fn test_rectangle() {
+    let r_u: Rectangle<u32> = Rectangle {
+        top: 0,
+        left: 0,
+        width: 100,
+        height: 100,
+    };
+
+    let r_f: Rectangle<f32> = Rectangle {
+        top: 0.0,
+        left: 0.0,
+        width: 100.05,
+        height: 100.05,
+    };
+
+    assert_eq!(r_u.width, 100);
+    assert_eq!(r_f.width, 100.05);
+}


### PR DESCRIPTION
The exercise includes 3 tasks, but the last one about turning `Rectangle` into a generic `struct` is untested.